### PR TITLE
Allow keys in cache to be used without claiming

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,9 +85,9 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-jar-plugin</artifactId>
             <version>2.3.1</version>
-            <configuration>
-               <outputDirectory>Z:\Spigot Test Server\plugins</outputDirectory>
-            </configuration>
+<!--            <configuration>-->
+<!--               <outputDirectory>Z:\Spigot Test Server\plugins</outputDirectory>-->
+<!--            </configuration>-->
          </plugin>
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/lootcrate/enums/Option.java
+++ b/src/main/java/lootcrate/enums/Option.java
@@ -2,7 +2,8 @@ package lootcrate.enums;
 
 public enum Option {
     DISPATCH_COMMAND_ITEM_AMOUNT("dispatch-command-item-time", DataType.BOOLEAN),
-    ADMIN_NOTIFICATIONS("admin-update-notification", DataType.BOOLEAN);
+    ADMIN_NOTIFICATIONS("admin-update-notification", DataType.BOOLEAN),
+    ALLOW_VIRTUAL_KEYS("allow-virtual-keys", DataType.BOOLEAN);
 
     String key;
     DataType type;

--- a/src/main/java/lootcrate/events/listeners/custom/CrateOpenListener.java
+++ b/src/main/java/lootcrate/events/listeners/custom/CrateOpenListener.java
@@ -31,6 +31,18 @@ public class CrateOpenListener implements Listener {
         Crate crate = e.getCrate();
         ItemStack item = p.getInventory().getItemInMainHand();
 
+        // If config allows virtual keys, check if they have the key in the cache
+        if (plugin.getOptionManager().valueOf(Option.ALLOW_VIRTUAL_KEYS)) {
+            if (plugin.getKeyCacheManager().contains(p.getUniqueId(), crate)) {
+                // They have the key in cache, remove then run the code as if they have the physical key
+                plugin.getKeyCacheManager().remove(p.getUniqueId(), crate);
+
+                plugin.getCrateManager().crateOpenEffects(crate, p);
+                openAnimation(crate, p);
+                return;
+            }
+        }
+
         // if they clicked w/same item as key && they match
 
         if (crate.getKey() == null || crate.getKey().getItem() == null || item == null) {

--- a/src/main/java/lootcrate/events/listeners/custom/CrateOpenListener.java
+++ b/src/main/java/lootcrate/events/listeners/custom/CrateOpenListener.java
@@ -32,15 +32,14 @@ public class CrateOpenListener implements Listener {
         ItemStack item = p.getInventory().getItemInMainHand();
 
         // If config allows virtual keys, check if they have the key in the cache
-        if (plugin.getOptionManager().valueOf(Option.ALLOW_VIRTUAL_KEYS)) {
-            if (plugin.getKeyCacheManager().contains(p.getUniqueId(), crate)) {
-                // They have the key in cache, remove then run the code as if they have the physical key
-                plugin.getKeyCacheManager().remove(p.getUniqueId(), crate);
+        if ((boolean) plugin.getOptionManager().valueOf(Option.ALLOW_VIRTUAL_KEYS) &&
+            plugin.getKeyCacheManager().contains(p.getUniqueId(), crate)) {
+            // They have the key in cache, remove then run the code as if they have the physical key
+            plugin.getKeyCacheManager().remove(p.getUniqueId(), crate);
 
-                plugin.getCrateManager().crateOpenEffects(crate, p);
-                openAnimation(crate, p);
-                return;
-            }
+            plugin.getCrateManager().crateOpenEffects(crate, p);
+            openAnimation(crate, p);
+            return;
         }
 
         // if they clicked w/same item as key && they match

--- a/src/main/java/lootcrate/managers/KeyCacheManager.java
+++ b/src/main/java/lootcrate/managers/KeyCacheManager.java
@@ -40,10 +40,17 @@ public class KeyCacheManager extends BasicManager {
         if(!cache.containsKey(uuid)) return;
 
         List<Integer> integerList = new ArrayList<>(getCrateIDSByUUID(uuid));
-        integerList.remove(integerList.indexOf(crate.getId()));
+        integerList.remove((Integer) crate.getId());
 
         cache.put(uuid, integerList);
 
+    }
+
+    public boolean contains(UUID uuid, Crate crate) {
+        if (!cache.containsKey(uuid))
+            return false;
+
+        return cache.get(uuid).contains(crate.getId());
     }
 
     private List<Integer> getCrateIDSByUUID(UUID uuid)

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -25,6 +25,9 @@ options:
     admin-update-notification: true
     # boolean - true/false
 
+    #Should people be able to use their key crates even before claiming them?
+    allow-virtual-keys: false
+    # boolean - true/false
     
 #+------------------------------+
 #|                              |


### PR DESCRIPTION
In `CrateOpenListener.java`, if config option `allow-virtual-keys` is true, check the player's key cache list. If they contain at least one integer that matches the crate ID the player is accessing, then remove that single occurrence from the cache and open the crate.

I also removed the configuration option in `pom.xml` as that caused an error in building the jar file.