### PR TITLE
Add reusable animated GUI frame and crate opening animation

### DIFF
--- a/src/main/java/lootcrate/events/listeners/custom/CrateOpenListener.java
+++ b/src/main/java/lootcrate/events/listeners/custom/CrateOpenListener.java
@@ -5,7 +5,11 @@ import lootcrate.LootCrate;
 import lootcrate.enums.Message;
 import lootcrate.enums.Option;
 import lootcrate.enums.Placeholder;
+import lootcrate.enums.AnimationStyle;
+import lootcrate.enums.CrateOptionType;
 import lootcrate.events.custom.CrateOpenEvent;
+import lootcrate.gui.frame.GuiFrame;
+import lootcrate.gui.frame.crate.CrateOpeningAnimationFrame;
 import lootcrate.managers.*;
 import lootcrate.objects.Crate;
 import lootcrate.utils.CommandUtils;
@@ -94,28 +98,23 @@ public class CrateOpenListener implements Listener {
     }
 
     private void openAnimation(Crate crate, Player p) {
-//        AnimatedFrame frame = null;
-//        CrateOption opt = crate.getOption(CrateOptionType.ANIMATION_STYLE);
-//        AnimationStyle type = AnimationStyle.valueOf((String) opt.getValue());
-//        switch (type) {
-//            case CSGO:
-//                frame = new CrateCSGOAnimationFrame(plugin, p, crate);
-//                break;
-//            case REMOVING_ITEM:
-//                frame = new CrateRemovingItemAnimationFrame(plugin, p, crate);
-//                break;
-//            case NONE:
-//                plugin.getManager(CrateManager.class).giveReward(plugin.getManager(CrateManager.class).getRandomItem(crate), p, crate.getName());
-//                return;
-//            default:
-//                frame = new CrateRandomGlassAnimationFrame(plugin, p, crate);
-//                break;
-//
-//        }
-//
-//        plugin.getManager(InventoryManager.class).openFrame(p, frame);
-//
-//        frame.showAnimation();
+        AnimationStyle type = AnimationStyle.RANDOM_GLASS;
+        if (crate.getOption(CrateOptionType.ANIMATION_STYLE) != null && crate.getOption(CrateOptionType.ANIMATION_STYLE).getValue() != null) {
+            String configured = crate.getOption(CrateOptionType.ANIMATION_STYLE).getValue().toString();
+            try {
+                type = AnimationStyle.valueOf(configured.toUpperCase());
+            } catch (IllegalArgumentException ignored) {
+                // keep default
+            }
+        }
+
+        if (type == AnimationStyle.NONE) {
+            plugin.getManager(CrateManager.class).giveReward(plugin.getManager(CrateManager.class).getRandomItem(crate), p, crate);
+            return;
+        }
+
+        GuiFrame frame = new CrateOpeningAnimationFrame(plugin, p, crate);
+        plugin.getManager(GuiManager.class).open(p, frame);
     }
 
 }

--- a/src/main/java/lootcrate/gui/frame/AbstractAnimatedFrame.java
+++ b/src/main/java/lootcrate/gui/frame/AbstractAnimatedFrame.java
@@ -1,0 +1,70 @@
+package lootcrate.gui.frame;
+
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+
+/**
+ * Base frame for GUI animations that progress over time.
+ */
+public abstract class AbstractAnimatedFrame extends AbstractGuiFrame implements AnimatedFrame {
+
+    private final int durationTicks;
+    private final int tickRate;
+
+    private boolean animationRunning;
+    private int elapsedTicks;
+
+    protected AbstractAnimatedFrame(JavaPlugin plugin, int size, String title, Player viewer, int durationTicks, int tickRate) {
+        super(plugin, size, title, viewer);
+        this.durationTicks = Math.max(1, durationTicks);
+        this.tickRate = Math.max(1, tickRate);
+    }
+
+    @Override
+    public void onOpen() {
+        startAnimation();
+    }
+
+    @Override
+    public void onClose() {
+        stopAnimation();
+    }
+
+    @Override
+    public void tick() {
+        if (!animationRunning) {
+            return;
+        }
+
+        elapsedTicks++;
+
+        if (elapsedTicks % tickRate == 0) {
+            onAnimationTick(elapsedTicks / tickRate);
+        }
+
+        if (elapsedTicks >= durationTicks) {
+            animationRunning = false;
+            onAnimationComplete();
+        }
+    }
+
+    @Override
+    public void startAnimation() {
+        this.animationRunning = true;
+        this.elapsedTicks = 0;
+    }
+
+    @Override
+    public void stopAnimation() {
+        this.animationRunning = false;
+    }
+
+    @Override
+    public boolean isAnimationRunning() {
+        return animationRunning;
+    }
+
+    protected abstract void onAnimationTick(int animationStep);
+
+    protected abstract void onAnimationComplete();
+}

--- a/src/main/java/lootcrate/gui/frame/AnimatedFrame.java
+++ b/src/main/java/lootcrate/gui/frame/AnimatedFrame.java
@@ -1,6 +1,10 @@
 package lootcrate.gui.frame;
 
 public interface AnimatedFrame extends GuiFrame {
-    @Override
-    default void tick() {}
+
+    void startAnimation();
+
+    void stopAnimation();
+
+    boolean isAnimationRunning();
 }

--- a/src/main/java/lootcrate/gui/frame/crate/CrateOpeningAnimationFrame.java
+++ b/src/main/java/lootcrate/gui/frame/crate/CrateOpeningAnimationFrame.java
@@ -1,0 +1,119 @@
+package lootcrate.gui.frame.crate;
+
+import lootcrate.LootCrate;
+import lootcrate.gui.CancelPolicy;
+import lootcrate.gui.GUIItem;
+import lootcrate.gui.frame.AbstractAnimatedFrame;
+import lootcrate.managers.CrateManager;
+import lootcrate.managers.GuiManager;
+import lootcrate.objects.Crate;
+import lootcrate.objects.CrateItem;
+import lootcrate.utils.ItemBuilder;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Reusable crate opening animation frame.
+ * <p>
+ * Shows a rotating glass border while quickly cycling reward previews,
+ * then gives the final reward once the animation ends.
+ */
+public class CrateOpeningAnimationFrame extends AbstractAnimatedFrame {
+
+    private static final int PREVIEW_SLOT = 13;
+    private static final int DURATION_TICKS = 60;
+
+    private final LootCrate plugin;
+    private final Crate crate;
+
+    private final List<Material> borderPalette = Arrays.asList(
+            Material.RED_STAINED_GLASS_PANE,
+            Material.ORANGE_STAINED_GLASS_PANE,
+            Material.YELLOW_STAINED_GLASS_PANE,
+            Material.LIME_STAINED_GLASS_PANE,
+            Material.LIGHT_BLUE_STAINED_GLASS_PANE,
+            Material.PURPLE_STAINED_GLASS_PANE
+    );
+
+    private CrateItem selectedReward;
+    private int paletteIndex;
+    private boolean rewardGiven;
+
+    public CrateOpeningAnimationFrame(LootCrate plugin, Player viewer, Crate crate) {
+        super(plugin, 27, "§8Opening §b" + crate.getName(), viewer, DURATION_TICKS, 2);
+        this.plugin = plugin;
+        this.crate = crate;
+    }
+
+    @Override
+    public void render() {
+        ItemStack filler = new ItemBuilder(Material.BLACK_STAINED_GLASS_PANE, plugin).name(" ").build();
+
+        for (int slot = 0; slot < getSize(); slot++) {
+            setItem(GUIItem.builder()
+                    .slot(slot)
+                    .itemStack(filler)
+                    .cancelPolicy(CancelPolicy.ALWAYS)
+                    .build());
+        }
+
+        applyBorderColor(borderPalette.get(paletteIndex));
+
+        setItem(GUIItem.builder()
+                .slot(PREVIEW_SLOT)
+                .itemStack(getPreviewItem())
+                .cancelPolicy(CancelPolicy.ALWAYS)
+                .build());
+    }
+
+    @Override
+    public boolean preventsClose() {
+        return isAnimationRunning();
+    }
+
+    @Override
+    protected void onAnimationTick(int animationStep) {
+        selectedReward = plugin.getManager(CrateManager.class).getRandomItem(crate);
+        paletteIndex = (paletteIndex + 1) % borderPalette.size();
+        plugin.getManager(GuiManager.class).refresh(getViewer());
+    }
+
+    @Override
+    protected void onAnimationComplete() {
+        if (rewardGiven || selectedReward == null) {
+            return;
+        }
+
+        rewardGiven = true;
+        plugin.getManager(CrateManager.class).giveReward(selectedReward, getViewer(), crate);
+        plugin.getManager(GuiManager.class).close(getViewer());
+    }
+
+    private ItemStack getPreviewItem() {
+        if (selectedReward == null) {
+            return new ItemBuilder(Material.ENDER_CHEST, plugin)
+                    .name("§eRolling reward...")
+                    .lore("§7Please wait")
+                    .build();
+        }
+
+        return selectedReward.getItem();
+    }
+
+    private void applyBorderColor(Material color) {
+        ItemStack border = new ItemBuilder(color, plugin).name(" ").build();
+        int[] borderSlots = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26};
+
+        for (int slot : borderSlots) {
+            setItem(GUIItem.builder()
+                    .slot(slot)
+                    .itemStack(border)
+                    .cancelPolicy(CancelPolicy.ALWAYS)
+                    .build());
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide a reusable, tick-driven animation system for GUI frames so crate openings (and other GUIs) can show an animation flow and block closing while running. 
- Restore and centralize crate opening animation behavior so different animation styles can be supported consistently.

### Description

- Strengthen the animated GUI contract by updating `AnimatedFrame` with explicit lifecycle methods `startAnimation()`, `stopAnimation()` and `isAnimationRunning()`.
- Add `AbstractAnimatedFrame` which implements timing, tick progression, and completion hooks to avoid duplicating animation logic across frames.
- Add `CrateOpeningAnimationFrame` as a reusable 27-slot opening animation that cycles a colored border, shows a rolling reward preview, then grants the selected reward and closes when complete.
- Wire crate opening logic in `CrateOpenListener` to read the configured `ANIMATION_STYLE` and either instantly give a reward for `NONE` or open the new `CrateOpeningAnimationFrame` for animated styles.

### Testing

- Ran `mvn -q -DskipTests compile` to validate compilation, which failed in this environment due to external Maven plugin resolution being blocked (HTTP 403 from `repository.apache.org`).
- No unit tests were added in this change and platform runtime verification was not possible here due to the environment's dependency resolution limitation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997bee41a988323a4eb1aa53e6ce129)